### PR TITLE
Fixed invalid request when using filters

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -607,6 +607,7 @@ function fetchData(options) {
         lastRequestBox = requestBoxString();
         if (icaoFilter) {
             if (icaoFilter.length > 0) {
+                url += '&box=' + lastRequestBox;
                 url += '&find_hex='
                 for (let k in icaoFilter) {
                     url += icaoFilter[k] + ','
@@ -614,6 +615,7 @@ function fetchData(options) {
                 url = url.slice(0, -1); // remove trailing comma
             }
         } else if (onlySelected && SelPlanes.length > 0) {
+            url += '&box=' + lastRequestBox;
             url += '&find_hex='
             for (let k in SelPlanes) {
                 url += SelPlanes[k].icao + ','


### PR DESCRIPTION
When you entered an airline or a specific callsign or ICAO24, the box parameter was missing in the API request which caused a http 400 response. This should fix it even if the filter parameter is ignored by the API.